### PR TITLE
[proposition] Introducing a "legacy" paragraph

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -233,8 +233,6 @@ menu_item: true
     is a GTK+JACK audio mixer app with a look similar to its hardware counterpart.
     It has lots of useful features, apart from being able to
     mix multiple JACKaudio streams. 
-  * [**JackMaster**](http://69b.org/cms/jackmaster)
-    is a Master Console. 
   * [**JackMiniMix**](http://www.aelius.com/njh/jackminimix)
     is a simple mixer with an [**OSC**](http://www.opensoundcontrol.org/)
     based control interface. 
@@ -242,6 +240,9 @@ menu_item: true
     is a Jack mixer. 
   * [**The Non Mixer**](http://non-mixer.tuxfamily.org/)
     is a powerful, reliable and fast modular Digital Audio Mixer. 
+### Legacy
+  * [**JackMaster**](http://69b.org/cms/jackmaster)
+    was a Master Console. 
 
 ## Multi-track sequencers and HDR systems
 

--- a/applications/index.md
+++ b/applications/index.md
@@ -240,7 +240,7 @@ menu_item: true
     is a Jack mixer. 
   * [**The Non Mixer**](http://non-mixer.tuxfamily.org/)
     is a powerful, reliable and fast modular Digital Audio Mixer. 
-### Legacy
+##### Legacy
   * [**JackMaster**](http://69b.org/cms/jackmaster)
     was a Master Console. 
 

--- a/applications/index.md
+++ b/applications/index.md
@@ -240,7 +240,7 @@ menu_item: true
     is a Jack mixer. 
   * [**The Non Mixer**](http://non-mixer.tuxfamily.org/)
     is a powerful, reliable and fast modular Digital Audio Mixer. 
-##### Legacy
+##### Legacy (mixers)
   * [**JackMaster**](http://69b.org/cms/jackmaster)
     was a Master Console. 
 


### PR DESCRIPTION
If I'm not wrong (_please correct me if I was_), jackmaster needs a GTK1 file (gtk-config) which isn't distributed anymore and hasn't been for a long time. Hence, jackmaster looks to be un-compilable nowadays.  Here, I'm proposing to create a "legacy" sub-section for this software.

On a longer view, I think it'd be great to do the same on the applications list in order to give a nice overview of the **currently working** applications and, in the same time, keeping the legacy of what has been working with jack too. Currently, the list contains some outdated applications which can then give a **not very state-of-the-art** picture of jack, hence misleading potential users/devs.
