### PR TITLE
Use relative_url(s) in links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,7 @@ name: JACK Audio Connection Kit
 markdown: Kramdown
 highlighter: rouge
 baseurl: ''
+
+repository:
+  branch: "master"
+  url: "https://github.com/jackaudio/jackaudio.github.com"

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@ exclude:
 name: JACK Audio Connection Kit
 markdown: Kramdown
 highlighter: rouge
-baseurl: ''
 
 repository:
   branch: "master"

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,11 @@ name: JACK Audio Connection Kit
 markdown: Kramdown
 highlighter: rouge
 
+url: "https://jackaudio.github.com"
+
+organization:
+  url: "https://github.com/jackaudio"
+
 repository:
   branch: "master"
   url: "https://github.com/jackaudio/jackaudio.github.com"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,13 +1,12 @@
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        <p class="copyright" style="text-align:left">Slate theme maintained by
-            <a href="https://github.com/jasoncostello">Jason Costello</a>
-            <span style="float:right">This site is open source.
-                <a href="{{site.repository.url}}/edit/{{site.repository.branch}}/{{page.path}}">
-                Improve this page</a>
-            </span>
-        </p>
-      </footer>
-    </div>
-
+        <!-- FOOTER  -->
+        <div id="footer_wrap" class="outer">
+            <footer class="inner">
+                <p class="copyright" style="text-align:left">Slate theme maintained by
+                    <a href="https://github.com/jasoncostello">Jason Costello</a>
+                    <span style="float:right">This site is open source.
+                        <a href="{{site.repository.url}}/edit/{{site.repository.branch}}/{{page.path}}">
+                        Improve this page</a>
+                    </span>
+                </p>
+            </footer>
+        </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,13 @@
     <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">
       <footer class="inner">
-        <p class="copyright">Slate theme maintained by <a href="https://github.com/jasoncostello">Jason Costello</a></p>
+        <p class="copyright" style="text-align:left">Slate theme maintained by
+            <a href="https://github.com/jasoncostello">Jason Costello</a>
+            <span style="float:right">This site is open source.
+                <a href="{{site.repository.url}}/edit/{{site.repository.branch}}/{{page.path}}">
+                Improve this page</a>
+            </span>
+        </p>
       </footer>
     </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,15 +1,14 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="https://github.com/jackaudio">View on GitHub</a>
-          <a href="{{site.baseurl}}{{site.url}}"> <img src="{{site.baseurl}}/images/logo.png" alt="home" border =
-          "0"> </a>
-
-          {% include nav_bar.html %}
-          <!--
-          <h1 id="project_title">{{site.name}}</h1>
-          <h2 id="project_tagline">TODO</h2>
-          -->
-
+            <a id="forkme_banner" href="https://github.com/jackaudio">View on GitHub</a>
+            <a href="{{ site.url | relative_url }}">
+                <img src="{{ '/images/logo.png' | relative_url }}" alt="home" border="0">
+            </a>
+            {% include nav_bar.html %}
+            <!--
+            <h1 id="project_title">{{site.name}}</h1>
+            <h2 id="project_tagline">TODO</h2>
+            -->
         </header>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,14 +1,14 @@
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-            <a id="forkme_banner" href="https://github.com/jackaudio">View on GitHub</a>
-            <a href="{{ site.url | relative_url }}">
-                <img src="{{ '/images/logo.png' | relative_url }}" alt="home" border="0">
-            </a>
-            {% include nav_bar.html %}
-            <!--
-            <h1 id="project_title">{{site.name}}</h1>
-            <h2 id="project_tagline">TODO</h2>
-            -->
-        </header>
-    </div>
+        <!-- HEADER -->
+        <div id="header_wrap" class="outer">
+            <header class="inner">
+                <a id="forkme_banner" href="{{ site.organization.url }}">View on GitHub</a>
+                <a href="{{ site.url | relative_url }}">
+                    <img src="{{ '/images/logo.png' | relative_url }}" alt="home" border="0">
+                </a>
+{% include nav_bar.html %}
+                <!--
+                <h1 id="project_title">{{site.name}}</h1>
+                <h2 id="project_tagline">TODO</h2>
+                -->
+            </header>
+        </div>

--- a/_includes/nav_bar.html
+++ b/_includes/nav_bar.html
@@ -1,11 +1,10 @@
 <nav>
-  <a href="{{site.baseurl}}/"> Home </a> |
-  <a href="{{site.baseurl}}/news/"> News </a> |
-  <a href="{{site.baseurl}}/applications/"> Applications </a> |
-  <a href="{{site.baseurl}}/faq/"> FAQ </a> |
-  <a href="https://github.com/jackaudio/jackaudio.github.com/wiki"> WIKI </a> |
-  <a href="{{site.baseurl}}/api/"> API </a> |
-  <a href="{{site.baseurl}}/downloads/"> Downloads </a> |
-  <a href="{{site.baseurl}}/community.html"> Community Network </a>
-
+    <a href="{{ '/' | relative_url }}"> Home </a> |
+    <a href="{{ '/news/' | relative_url }}"> News </a> |
+    <a href="{{ '/applications/' | relative_url }}"> Applications </a> |
+    <a href="{{ '/faq/' | relative_url }}"> FAQ </a> |
+    <a href="{{ 'https://github.com/jackaudio/jackaudio.github.com/wiki' | relative_url }}"> WIKI </a> |
+    <a href="{{ '/api/' }}"> API </a> |
+    <a href="{{ '/downloads/' | relative_url }}"> Downloads </a> |
+    <a href="{{ '/community.html' | relative_url }}"> Community Network </a>
 </nav>

--- a/_includes/nav_bar.html
+++ b/_includes/nav_bar.html
@@ -1,10 +1,10 @@
-<nav>
-    <a href="{{ '/' | relative_url }}"> Home </a> |
-    <a href="{{ '/news/' | relative_url }}"> News </a> |
-    <a href="{{ '/applications/' | relative_url }}"> Applications </a> |
-    <a href="{{ '/faq/' | relative_url }}"> FAQ </a> |
-    <a href="{{ 'https://github.com/jackaudio/jackaudio.github.com/wiki' | relative_url }}"> WIKI </a> |
-    <a href="{{ '/api/' }}"> API </a> |
-    <a href="{{ '/downloads/' | relative_url }}"> Downloads </a> |
-    <a href="{{ '/community.html' | relative_url }}"> Community Network </a>
-</nav>
+                <nav>
+                    <a href="{{ '/' | relative_url }}"> Home </a> |
+                    <a href="{{ '/news/' | relative_url }}"> News </a> |
+                    <a href="{{ '/applications/' | relative_url }}"> Applications </a> |
+                    <a href="{{ '/faq/' | relative_url }}"> FAQ </a> |
+                    <a href="{{ site.repository.url | append: '/wiki' | relative_url }}"> WIKI </a> |
+                    <a href="{{ '/api/' }}"> API </a> |
+                    <a href="{{ '/downloads/' | relative_url }}"> Downloads </a> |
+                    <a href="{{ '/community.html' | relative_url }}"> Community Network </a>
+                </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset='utf-8' />
-    <meta name="description" content="{{site.name}}|{{page.title}}" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-    <title>{{site.name}}|{{page.title}}</title>
-  </head>
-  <body>
-    {% include header.html %}
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
-        {{ content }}
-      </section>
-    </div>
-    {% include footer.html %}
-  </body>
+    <head>
+        <meta charset='utf-8' />
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
+    </head>
+    <body>
+        {% include header.html %}
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+        <section id="main_content" class="inner">
+            {{ content }}
+        </section>
+        </div>
+        {% include footer.html %}
+    </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,13 +8,13 @@
         <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
-        {% include header.html %}
+{% include header.html %}
         <!-- MAIN CONTENT -->
         <div id="main_content_wrap" class="outer">
-        <section id="main_content" class="inner">
-            {{ content }}
-        </section>
+            <section id="main_content" class="inner">
+{{ content }}
+            </section>
         </div>
-        {% include footer.html %}
+{% include footer.html %}
     </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset='utf-8' />
-    <meta name="description" content="{{site.name}}|{{page.title}}" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-    <title>{{site.name}}|{{page.title}}</title>
-  </head>
-  <body>
-    {% include header.html %}
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
-        {{ content }}
-      </section>
-    </div>
-    {% include footer.html %}
-  </body>
+    <head>
+        <meta charset='utf-8' />
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
+    </head>
+    <body>
+        {% include header.html %}
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+        <section id="main_content" class="inner">
+            {{ content }}
+        </section>
+        </div>
+        {% include footer.html %}
+    </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -8,13 +8,13 @@
         <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
-        {% include header.html %}
+{% include header.html %}
         <!-- MAIN CONTENT -->
         <div id="main_content_wrap" class="outer">
-        <section id="main_content" class="inner">
-            {{ content }}
-        </section>
+            <section id="main_content" class="inner">
+{{ content }}
+            </section>
         </div>
-        {% include footer.html %}
+{% include footer.html %}
     </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset='utf-8' />
-    <meta name="description" content="{{site.name}}|{{page.title}}" />
-    <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-    <title>{{site.name}}|{{page.title}}</title>
-  </head>
-  <body>
-    {% include header.html %}
-    <!-- MAIN CONTENT -->
-    <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
-        {{ content }}
-      </section>
-    </div>
-    {% include footer.html %}
-  </body>
+    <head>
+        <meta charset='utf-8' />
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
+    </head>
+    <body>
+        {% include header.html %}
+        <!-- MAIN CONTENT -->
+        <div id="main_content_wrap" class="outer">
+        <section id="main_content" class="inner">
+            {{ content }}
+        </section>
+        </div>
+        {% include footer.html %}
+    </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,13 +8,13 @@
         <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
-        {% include header.html %}
+{% include header.html %}
         <!-- MAIN CONTENT -->
         <div id="main_content_wrap" class="outer">
-        <section id="main_content" class="inner">
-            {{ content }}
-        </section>
+            <section id="main_content" class="inner">
+{{ content }}
+            </section>
         </div>
-        {% include footer.html %}
+{% include footer.html %}
     </body>
 </html>

--- a/atom.xml
+++ b/atom.xml
@@ -3,7 +3,7 @@ layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>News</title>
+    <title>{{ site.name }} News</title>
     <link href="{{ site.url }}/atom.xml" rel="self"/>
     <link href="{{ site.url }}"/>
     <updated>{{ site.time | date_to_xmlschema }}</updated>


### PR DESCRIPTION
This set of changes fixes:
- A problem when hosting the website pages in a [subpath rather than the root of the domain],
  see also #106, this is needed to help forks to be tested in a user, non-organization account repository. The problem can be seen [here] at this time
- Some hardcoded links that once moved can lead to many 404 in future, so set them in a _config.yml variable helps to make it easier to change them in one place
- Layout indentation

[subpath rather than the root of the domain]: https://jekyllrb.com/docs/liquid/filters/
[here]: https://redtide.github.io/jackaudio.github.com/