### PR TITLE
Use relative_url(s) in links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,11 @@ exclude:
 name: JACK Audio Connection Kit
 markdown: Kramdown
 highlighter: rouge
-baseurl: ''
+
+url: "https://jackaudio.github.com"
+
+organization:
+  url: "https://github.com/jackaudio"
 
 repository:
   branch: "master"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,10 @@
         <!-- HEADER -->
         <div id="header_wrap" class="outer">
             <header class="inner">
-                <a id="forkme_banner" href="https://github.com/jackaudio">View on GitHub</a>
-                <a href="{{site.baseurl}}{{site.url}}"> <img src="{{site.baseurl}}/images/logo.png" alt="home" border =
-                "0"> </a>
+                <a id="forkme_banner" href="{{ site.organization.url }}">View on GitHub</a>
+                <a href="{{ site.url | relative_url }}">
+                    <img src="{{ '/images/logo.png' | relative_url }}" alt="home" border="0">
+                </a>
 {% include nav_bar.html %}
                 <!--
                 <h1 id="project_title">{{site.name}}</h1>

--- a/_includes/nav_bar.html
+++ b/_includes/nav_bar.html
@@ -1,10 +1,10 @@
                 <nav>
-                    <a href="{{site.baseurl}}/"> Home </a> |
-                    <a href="{{site.baseurl}}/news/"> News </a> |
-                    <a href="{{site.baseurl}}/applications/"> Applications </a> |
-                    <a href="{{site.baseurl}}/faq/"> FAQ </a> |
-                    <a href="https://github.com/jackaudio/jackaudio.github.com/wiki"> WIKI </a> |
-                    <a href="{{site.baseurl}}/api/"> API </a> |
-                    <a href="{{site.baseurl}}/downloads/"> Downloads </a> |
-                    <a href="{{site.baseurl}}/community.html"> Community Network </a>
+                    <a href="{{ '/' | relative_url }}"> Home </a> |
+                    <a href="{{ '/news/' | relative_url }}"> News </a> |
+                    <a href="{{ '/applications/' | relative_url }}"> Applications </a> |
+                    <a href="{{ '/faq/' | relative_url }}"> FAQ </a> |
+                    <a href="{{ site.repository.url | append: '/wiki' | relative_url }}"> WIKI </a> |
+                    <a href="{{ '/api/' }}"> API </a> |
+                    <a href="{{ '/downloads/' | relative_url }}"> Downloads </a> |
+                    <a href="{{ '/community.html' | relative_url }}"> Community Network </a>
                 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,9 +2,10 @@
 <html>
     <head>
         <meta charset='utf-8' />
-        <meta name="description" content="{{site.name}}|{{page.title}}" />
-        <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-        <title>{{site.name}}|{{page.title}}</title>
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
 {% include header.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,9 +2,10 @@
 <html>
     <head>
         <meta charset='utf-8' />
-        <meta name="description" content="{{site.name}}|{{page.title}}" />
-        <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-        <title>{{site.name}}|{{page.title}}</title>
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
 {% include header.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,9 +2,10 @@
 <html>
     <head>
         <meta charset='utf-8' />
-        <meta name="description" content="{{site.name}}|{{page.title}}" />
-        <link rel="stylesheet" type="text/css" media="screen" href="{{site.baseurl}}/stylesheets/stylesheet.css">
-        <title>{{site.name}}|{{page.title}}</title>
+        <meta name="description" content="{{ site.name }} | {{ page.title }}" />
+        <link rel="stylesheet" type="text/css" media="screen"
+            href="{{ '/stylesheets/stylesheet.css' | relative_url }}">
+        <title>{{ site.name }} | {{ page.title }}</title>
     </head>
     <body>
 {% include header.html %}


### PR DESCRIPTION
This set of changes fixes:

- A problem when hosting the website pages in a [subpath rather than the root of the domain],
  see also #106, this is needed to help forks to be tested in a user,
  non-organization account repository. The problem can be seen [here] at this time
- Some hardcoded links that once moved can lead to many 404 in future, so set them
  in a _config.yml variable helps to make it easier to change them in one place
- the [baseurl] prefix is not needed anymore in recent Jekyll versions and will also unsupported in v4.0.0

[subpath rather than the root of the domain]: https://jekyllrb.com/docs/liquid/filters/
[here]: https://redtide.github.io/jackaudio.github.com/
[baseurl]: https://jekyllrb.com/news/releases/#super-powered-content-transformations-
