### PR TITLE
Removed open movie editor from video applications

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -667,9 +667,6 @@ title:  "Applications"
   * [**LiVES**](http://lives.sourceforge.net/)
     is a Video Editing System. It is designed to be simple to use, yet powerful.
     It is small in size, yet it has many advanced features.
-  * [**Open Movie Editor**](http://openmovieeditor.sourceforge.net/)
-    is designed to be a simple tool, that provides
-    basic movie making capabilities.
     It aims to be powerful enough for the amateur movie artist, yet easy to use.
   * [**VideoJack**](http://www.piksel.no/pwiki/VideoJack)
     a tool that reads video and audio signals from its jack inputs.


### PR DESCRIPTION
Open Movie Editor last saw a release in 2009. It is no longer packaged on any modern linux os and even the developer has abandoned the project (source https://en.wikipedia.org/wiki/Open_Movie_Editor ). For this reason it should be removed from the list.