### PR TITLE
Removed dead link

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -99,8 +99,6 @@ title:  "Applications"
     is a simple Linux amplifier with one input and two outputs.
   * [**IEM Plug-in Suite**](https://plugins.iem.at/)
     is a set of VST-plugins (with a DAW independent standalone-mode) for Ambisonics sound field encoding, analysis, processing and decoding.
-  * [**jackEQ**](http://jackeq.sourceforge.net/)
-    a tool for routing and manipulating audio from/to multiple input/output sources.
   * [**JAMin**](http://jamin.sourceforge.net/)
     the state-of-the-art realtime mastering processor.
   * [**linuxDSP**](http://www.linuxdsp.co.uk/)


### PR DESCRIPTION
The Wayback Machine has archived [a copy of the project page](https://web.archive.org/web/20190903080444/https://jackeq.sourceforge.net/), but has not archived the actual source code on SourceForge. Unless someone else has archived this somewhere else, the source code has been lost.

The project page (in fact the entire djcj.org site) has been stolen by what appears to be a domain squatter.