### PR TITLE
Semi-fix broken link

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -99,8 +99,9 @@ title:  "Applications"
     is a simple Linux amplifier with one input and two outputs.
   * [**IEM Plug-in Suite**](https://plugins.iem.at/)
     is a set of VST-plugins (with a DAW independent standalone-mode) for Ambisonics sound field encoding, analysis, processing and decoding.
-  * [**jackEQ**](http://jackeq.sourceforge.net/)
+  * [**jackEQ**](https://sourceforge.net/projects/jackeq/)
     a tool for routing and manipulating audio from/to multiple input/output sources.
+    ([An archived copy of the original (now dead) project site](https://web.archive.org/web/20190830084309/http://djcj.org/jackeq/) is available.)
   * [**JAMin**](http://jamin.sourceforge.net/)
     the state-of-the-art realtime mastering processor.
   * [**linuxDSP**](http://www.linuxdsp.co.uk/)


### PR DESCRIPTION
The project site has been taken over by what appears to be a domain squatter. The Internet Archive has [a copy of the original project site from 2019](https://web.archive.org/web/20190903080444/https://jackeq.sourceforge.net/) and [source code](https://sourceforge.net/projects/jackeq/) appears to be still intact on SourceForge.