### PR TITLE
Found the disappeared project (creox), reinstating

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -87,6 +87,8 @@ title:  "Applications"
     a software convolution engine.
   * [**CP-GFX**](http://cp-gfx.sourceforge.net/)
     Guitar effects processor.
+  * [**creox**](https://github.com/laudrup/Creox4)
+    a realtime sound processor.
   * [**DSSI**](http://dssi.sourceforge.net/)
     is an API for audio processing plugins, particularly useful for
     software synthesis plugins with user interfaces.


### PR DESCRIPTION
Found [a copy of the dead project page on the Wayback Machine](https://web.archive.org/web/20190805135406/https://zyzstar.kosoru.com/?creox), which lists [the project’s new home on github](https://github.com/laudrup/Creox4), so the project should be put back in.

This reverts commit d952653af2f5fba9a5f751fdba6bf345d96ce4ed (my first pull request). I was not being careful when I made my original proposed edit. I’m really sorry I was not more careful.