### PR TITLE
Moved dead project to (new) legacy section

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -90,8 +90,6 @@ title:  "Applications"
   * [**DSSI**](http://dssi.sourceforge.net/)
     is an API for audio processing plugins, particularly useful for
     software synthesis plugins with user interfaces.
-  * [**Ecamegapedal**](http://www.eca.cx/ecamegapedal/)
-    a real-time effect processor. Version 0.4.0 or above.
   * [**freqtweak**](http://freqtweak.sourceforge.net/)
     a frequency domain FX box. This is one of the coolest FX boxes
     you may ever use.
@@ -120,6 +118,10 @@ title:  "Applications"
     is an audio effects processor inspired by
     the classical magnetic tape delay systems.
     Version 0.7.0 or above.
+
+##### Legacy (effects processors)
+  * [**Ecamegapedal**](https://web.archive.org/web/20130606111504/http://www.eca.cx:80/ecamegapedal/)
+    was a real-time effect processor.
 
 ## Graphics Applications
 


### PR DESCRIPTION
[The Wayback Machine’s latest valid archive of the original project page on the Wayback Machine](https://web.archive.org/web/20130606111504/http://www.eca.cx:80/ecamegapedal/) shows that the project stopped development by 2013. [The next attempt to archive it again (in 2014)](https://web.archive.org/web/20131209042023/http://www.eca.cx:80/ecamegapedal/) already resulted in a 404.