### PR TITLE
Add Jamulus as JACK enabled application

### DIFF
--- a/faq/jack_on_windows.md
+++ b/faq/jack_on_windows.md
@@ -30,6 +30,7 @@ Several applications have native JACK support:
   * [Carla Plugin Host](https://kx.studio/Applications:Carla)
   * [Foo YC20](https://github.com/sampov2/foo-yc20)
   * [Harisson MixBus](https://harrisonconsoles.com/product/mixbus/)
+  * [Jamulus](https://jamulus.io) (starting from Version 3.8.1 as separate build)
   * [LMMS](https://lmms.io/) (starting from v1.3)
   * [MuseScore](http://musescore.org/)
   * [Radium](http://users.notam02.no/~kjetism/radium/)


### PR DESCRIPTION
This PR adds https://github.com/jamulussoftware/jamulus as JACK enabled application. We provide a JACK build since quite some time.