### PR TITLE
Add Mash, a very precise Jack MIDI virtual keyboard

### DIFF
--- a/applications/index.md
+++ b/applications/index.md
@@ -507,6 +507,8 @@ title:  "Applications"
     a drum machine.
   * [**LinuxSampler**](http://www.linuxsampler.org/)
     a software audio sampler.
+  * [**Mash**](https://github.com/capocasa/mash)
+    is a headless, very precise virtual MIDI keyboard for Jack.
   * [**Midi Player Pro**](http://www.selasky.org/hans_petter/midistudio)
     is the software you need to be able to play any kind of music
     in seconds with your fingertips. It uses

--- a/applications/index.md
+++ b/applications/index.md
@@ -358,6 +358,8 @@ title:  "Applications"
     in asynchronous mode.
   * [**libjackmm**](http://sourceforge.net/projects/libjackmm)
     is a C++ interface to the jack audio connection kit.
+  * [**jill**](https://github.com/capocasa/jill)
+    is a quick 'n easy jack interface in the Nim programming language
   * [**Praxis Live**](http://www.praxislive.org/)
     is an hybrid visual live programming for creatives,
     for programmers, for students, for tinkerers.


### PR DESCRIPTION
It's a headless (no GUI) Jack MIDI virtual keyboard that directly plugs into the low level linux audio drivers and uses the kernel timestamps. The "playing feel" is much better than keyboards that use the window system drivers and there are no issues with keyboard layout. It's almost ata the point where you can consider your computer a real instrument, at least for instruments that traditionally don't have touch sensitivity like organs.